### PR TITLE
Expand thavel to Thibaut Havel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 thavel
+Copyright (c) 2014 Thibaut Havel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='synolopy',
     version='0.1.1',
     description='Synology Python API',
-    author='thavel',
+    author='Thibaut Havel',
     packages=find_packages(),
     requires=[
         'requests'


### PR DESCRIPTION
It is probably better to use first/last name to reference the author.
